### PR TITLE
filesystems.md reference to sysutils/automount

### DIFF
--- a/user/components/filesystems.md
+++ b/user/components/filesystems.md
@@ -11,6 +11,6 @@ Additionally, the following filesystems are supported in helloSystem, but it can
 * XFS (SGI)
 * MTP (Android)
 
-Supported filesystems are automatically mounted by [automount](https://github.com/vermaden/automount).
+Supported filesystems are automatically mounted by [sysutils/automount](https://www.freshports.org/sysutils/automount/).
 
 To see how they are mounted, open the Logs utility and attach a disk.


### PR DESCRIPTION
`sysutils/automount` not to be confused with the `automount` that's integral to FreeBSD. 

https://www.freshports.org/sysutils/automount/ includes a link to https://github.com/vermaden/automount/