### PR TITLE
chore: fix epub cover and TOC

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -81,7 +81,8 @@ html_show_copyright = False
 html_show_sphinx = False
 html_logo = "_static/hello_logo.png"
 
-epub_cover = ('_static/hello_logo.png', 'epub-cover.html')
+epub_cover = ('./_static/hello_logo.png', 'epub-cover.html')
+epub_tocscope = "includehidden"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Closes #7 

This PR updates the epub cover path in the configuration file to be absolute. It also enables the epub to be built with hidden table of contents so that users can easily navigate through the book.

![Screenshot_2023-02-06_06-12-57](https://user-images.githubusercontent.com/29224057/216889147-d11f281f-42af-47d0-9d18-322e9c78777b.png)
