### PR TITLE
Revert "chore: fix epub cover and TOC"

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -81,8 +81,7 @@ html_show_copyright = False
 html_show_sphinx = False
 html_logo = "_static/hello_logo.png"
 
-epub_cover = ('./_static/hello_logo.png', 'epub-cover.html')
-epub_tocscope = "includehidden"
+epub_cover = ('_static/hello_logo.png', 'epub-cover.html')
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Reverts helloSystem/docs#49

Cover was not rendered properly in Lector.app (our default EPUB reader)

![image](https://user-images.githubusercontent.com/2480569/217084544-5235aec0-62c6-4367-a654-4119e08a654e.png)
